### PR TITLE
[Step7] 대규모트래픽&데이터처리 2

### DIFF
--- a/src/main/kotlin/kr/hhplus/be/server/ServerApplication.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/ServerApplication.kt
@@ -2,7 +2,9 @@ package kr.hhplus.be.server
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableScheduling
 
+@EnableScheduling
 @SpringBootApplication
 class ServerApplication
 

--- a/src/main/kotlin/kr/hhplus/be/server/application/ConcertService.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/application/ConcertService.kt
@@ -1,13 +1,24 @@
 package kr.hhplus.be.server.application
 
+import kr.hhplus.be.server.enums.ReservationStatus
 import kr.hhplus.be.server.infrastructure.persistence.ConcertJpaRepo
+import kr.hhplus.be.server.infrastructure.persistence.ConcertScheduleJpaRepo
+import kr.hhplus.be.server.infrastructure.persistence.ConcertSeatJpaRepo
 import kr.hhplus.be.server.interfaces.dto.ConcertDto.ConcertResponseDto
+import org.redisson.api.RedissonClient
+import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 
 @Service
 class ConcertService(
-    private val concertJpaRepo: ConcertJpaRepo
+    private val concertJpaRepo: ConcertJpaRepo,
+    private val concertScheduleJpaRepo: ConcertScheduleJpaRepo,
+    private val concertSeatJpaRepo: ConcertSeatJpaRepo,
+    private val redissonClient: RedissonClient,
 ) {
+    companion object {
+        private const val IMMINENT_CONCERT_RANKING_KEY = "concert:imminent_ranking"
+    }
 
     /**
      * 콘서트 정보 조회
@@ -18,5 +29,42 @@ class ConcertService(
             ?: throw IllegalStateException("존재하지 않는 콘서트 입니다.")
 
         return concertEntity.toDto()
+    }
+
+    /**
+     * 매진 임박 콘서트 업데이트 배치
+     */
+    @Scheduled(fixedRate = 300000) // 5분 스케줄링
+    fun updateImminentConcertRanking() {
+        val zSet = redissonClient.getScoredSortedSet<String>(
+            IMMINENT_CONCERT_RANKING_KEY
+        )
+
+        // TODO: 매진 콘서트 별도 플래그 혹은 이미 지난 콘서트 유무 처리 필요
+        val allConcerts = concertJpaRepo.findAll()
+
+        allConcerts.forEach { concert ->
+
+            val schedules = concertScheduleJpaRepo.findByConcertId(
+                concert.uuid
+            )
+
+            // 남은 좌석수 합산
+            var totalAvailableSeats = 0L
+            schedules.forEach { schedule ->
+                totalAvailableSeats += concertSeatJpaRepo.countByConcertScheduleIdAndStatus(
+                    schedule.uuid,
+                    ReservationStatus.AVAILABLE
+                )
+            }
+
+            // Redis 랭킹 업데이트
+            zSet.add(totalAvailableSeats.toDouble(), concert.uuid)
+
+            // 매진이면 랭킹에서 제거
+            if (totalAvailableSeats == 0L) {
+                zSet.remove(concert.uuid)
+            }
+        }
     }
 }

--- a/src/main/kotlin/kr/hhplus/be/server/application/ConcertService.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/application/ConcertService.kt
@@ -8,6 +8,7 @@ import kr.hhplus.be.server.interfaces.dto.ConcertDto.ConcertResponseDto
 import org.redisson.api.RedissonClient
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
+import java.util.stream.Collectors
 
 @Service
 class ConcertService(
@@ -29,6 +30,31 @@ class ConcertService(
             ?: throw IllegalStateException("존재하지 않는 콘서트 입니다.")
 
         return concertEntity.toDto()
+    }
+
+    /**
+     * 매진 임박 콘서트 랭킹 조회
+     */
+    fun getImminentConcerts(): List<ConcertResponseDto> {
+        val zSet = redissonClient.getScoredSortedSet<String>(
+            IMMINENT_CONCERT_RANKING_KEY
+        )
+
+        // 오름차순 상위 5개 조회 (점수가 작을 수록 매진임박)
+        val rankedConcertIds = zSet.valueRange(0, 4)
+        if (rankedConcertIds.isEmpty()) {
+            return listOf()
+        }
+
+        val concerts = concertJpaRepo.findByUuidIn(rankedConcertIds)
+        val concertMap = concerts.associateBy { it.uuid }
+
+        // TODO: 남은 좌석수 표시 여부 결정
+        return rankedConcertIds.stream()
+            .map { concertMap[it] }
+            .map { it?.toDto() }
+            .collect(Collectors.toList())
+            .filterNotNull()
     }
 
     /**

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/persistence/ConcertJpaRepo.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/persistence/ConcertJpaRepo.kt
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository
 @Repository
 interface ConcertJpaRepo : JpaRepository<ConcertEntity, Long> {
     fun findByUuid(uuid: String): ConcertEntity?
+    fun findByUuidIn(uuids: Collection<String>): List<ConcertEntity>
 }

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/persistence/ConcertSeatJpaRepo.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/persistence/ConcertSeatJpaRepo.kt
@@ -2,6 +2,7 @@ package kr.hhplus.be.server.infrastructure.persistence
 
 import jakarta.persistence.LockModeType
 import kr.hhplus.be.server.entity.ConcertSeatEntity
+import kr.hhplus.be.server.enums.ReservationStatus
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
 import org.springframework.stereotype.Repository
@@ -12,4 +13,8 @@ interface ConcertSeatJpaRepo : JpaRepository<ConcertSeatEntity, Long> {
     fun findByUuid(concertSeatId: String): ConcertSeatEntity?
 
     fun findByConcertScheduleId(concertScheduleId: String): List<ConcertSeatEntity>
+
+    fun countByConcertScheduleIdAndStatus(
+        concertScheduleId: String, status: ReservationStatus
+    ): Long
 }

--- a/src/main/kotlin/kr/hhplus/be/server/interfaces/web/ConcertController.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/interfaces/web/ConcertController.kt
@@ -46,4 +46,12 @@ class ConcertController(
             )
         )
     }
+
+    @GetMapping("/imminent")
+    fun getImminentConcerts()
+            : CommonResponseDto<List<ConcertResponseDto>> {
+        return CommonResponseDto(
+            concertService.getImminentConcerts()
+        )
+    }
 }


### PR DESCRIPTION
### 개요

- 매진임박 콘서트 목록 조회 기능 추가
Redis 랭킹(Sorted Set) 사용


### **주요 커밋 설명**

- 18a069c
매진이 임박한 콘서트의 남은 좌석수를 Redis에 업데이트 하는 로직 추가

- de9ec42
매진 임박 콘서트 조회 API 추가

---

### **리뷰 받고 싶은 내용(질문)**

- 매진임박 목록 리팩토링 방향 (18a069c)

우선 간단한 구현 및 빠른 진행을 위해 배치 작업으로 랭킹을 업데이트 하도록 구현하였습니다. 
추가로 고려하고 있는건 좌석을 임시점유 한 이후 남은 좌석을 줄이는 로직을 넣어두는 작업입니다.

한편으로는 러프하게 생각하면 인기 콘서트 목록 정도로 볼 수도 있을 것 같은데,
실시간적으로 남은 좌석이 계산될 필요까지 없어도 되지 않나 라는 고민도 됩니다.

실시간적 반영이 필요하지 않은 랭킹이라면 지금과 같이 배치 스케줄링정도로 관리하면 될지 의견 부탁드립니다.

---

### **과제 셀프 피드백 및 기술적 성장**

- 지금까지는 Redis를 써도 jwt 토큰 저장소 혹은 간단한 캐시 저장용으로만 썼는데, 더욱 다양한 용도로 사용할 수 있음을 배웠다.
- 아직은 그래도 코드에서 redis 관련 로직 혹은 메서드를 쓰는데 익숙하진 않아서 더 학습이 필요하다.

---